### PR TITLE
Add file extension names to languages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .scraper_env
 src/__pycache__
+.vscode

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,7 @@
 import os
 import datetime
 import github_api as git_api
-
+import process_repo
 
 
 print('----------------------')
@@ -19,8 +19,9 @@ now = datetime.datetime.now()
 '''
 repo_name = 'ravilladhaneesh/github-viewer'
 repo_path = os.getcwd()
-repo_branch = 'dummy'
+branch = 'dummy'
 repo_url = 'https://github.com/ravilladhaneesh/github-viewer'
+repo_visibility = True
 '''
 
 
@@ -39,54 +40,22 @@ print(f'current time: {now}')
 print('---------------------')
 
 
-def get_files_of_non_master_branch(repo_path):
- 
-    excluded_dirs = {'.git', '.github', 'github-scraper'}
-    #local testing
-    #excluded_dirs = = {'.git', '.github', 'github-scraper', '.venv', '__pycache__'}
-    USERNAME, REPO = repo_name.split('/')
-
-    #file_extensions = ['py', 'css', 'html', 'txt', 'java']
-
-    file_extensions = {}
-
-    for dirpath, dirnames, filenames in os.walk(repo_path):
-        dirnames[:] = [d for d in dirnames if d not in excluded_dirs]
-                
-        #print(f"\nDirectory: {dirpath}")
-                
-        for file in filenames:
-            #print(f"  File: {file}")
-            if not file.startswith('.git'):
-                extension = file.split('.')[-1]
-                if extension in file_extensions:
-                    file_extensions[extension] += 1
-                else:
-                    file_extensions[extension] = 1
-
-    for extension, value in file_extensions.items():
-        print(extension, value)
-    return file_extensions
-
-def get_languages_percentage(languages):
-    cal_percentage = lambda x: (x / percentage_sum ) * 100
-    percentage_sum = sum(languages.values())
-    languages_percentage = {lang: round(cal_percentage(languages[lang]), 2) for lang in languages}
-    print(languages_percentage)
-    return languages_percentage
-
-
-def process_repo(name, branch, url, path):
+"""
+Function that processes the repo and gets the repo data
+"""
+def get_repo_data(name, branch, url, path):
 
     default_branches = {'master', 'main'}
     
     if branch in default_branches:
         languages_data = git_api.get_languages(name)
     else:
-        languages_data = get_files_of_non_master_branch(path)
-        
+        languages_data = process_repo.get_files_of_non_default_branch(name, path)
 
-    languages_percentage = get_languages_percentage(languages_data)
+    languages_percentage = process_repo.get_languages_percentage(languages_data)
+    map_language_names = process_repo.get_languages(languages_percentage)
+    print(map_language_names)
 
 
-process_repo(repo_name, branch, repo_url, repo_path)
+
+get_repo_data(repo_name, branch, repo_url, repo_path)

--- a/src/process_repo.py
+++ b/src/process_repo.py
@@ -1,0 +1,78 @@
+import os
+
+file_extensions = {
+    'py': 'python',
+    'java': 'java',
+    'c': 'C', 
+    'cpp': 'c++',
+    'js': 'javascript',
+    'html': 'HTML',
+    'css': 'CSS',
+    'tf': 'HCL',
+    'txt': 'text',
+    'json': 'JSON',
+    'md': 'markdown'
+}
+
+
+"""
+Function to find all the different files in the directory
+"""
+def get_files_of_non_default_branch(repo_name, repo_path):
+     
+    excluded_dirs = { 'github-scraper', '__pycache__'}
+    #local testing
+    #excluded_dirs = = {'.git', '.github', 'github-scraper', '.venv', '__pycache__'}
+    USERNAME, REPO = repo_name.split('/')
+
+    #file_extensions = ['py', 'css', 'html', 'txt', 'java']
+
+    file_extensions = {}
+
+    for dirpath, dirnames, filenames in os.walk(repo_path):
+        
+        # print('\nDirnames', dirnames)
+        # print(f"\nDirectory: {dirpath}")
+        # print("\nfilesNames:", filenames)
+        dirnames[:] = [d for d in dirnames if d not in excluded_dirs and not d.startswith(".")]
+                
+        for file in filenames:
+            #print(f"  File: {file}")
+            if not file.startswith('.git'):
+                extension = file.split('.')[-1]
+                if extension in file_extensions:
+                    file_extensions[extension] += 1
+                else:
+                    file_extensions[extension] = 1
+        # print("\n-------------------------\n")
+
+    for extension, value in file_extensions.items():
+        print(extension, value)
+    return file_extensions
+
+"""
+Calculate the percentage of each file in the repo based on count
+"""
+def get_languages_percentage(languages):
+    cal_percentage = lambda x: (x / percentage_sum ) * 100
+    percentage_sum = sum(languages.values())
+    languages_percentage = {lang: round(cal_percentage(languages[lang]), 2) for lang in languages}
+    #print(languages_percentage)
+    return languages_percentage
+
+
+"""
+The function processes the languages dictionary with file extensions shortform as keys and
+return keys with know file extension name
+
+Ex: .py as python, .tf as HCL
+"""
+def get_languages(languages):
+    lang = {}
+    for key, value in languages.items():
+        if key in file_extensions.keys():
+            lang[file_extensions[key]] = value
+        else:
+            lang[key] = value
+    
+    return lang


### PR DESCRIPTION
Previously the languages dict has file extensions as its keys.
The code is updated to have the corresponding file extension names as its keys.
The file extension names are limited and supports only for few file extensions.
The know file extensions can be found in src/process_repo.file_extensions variable